### PR TITLE
Fix plando/itemlinks and settings behavior, minor cleanup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 *.smc
 __pycache__/*
 basepatch/*
+# PyCharm
+.idea/

--- a/__init__.py
+++ b/__init__.py
@@ -1,22 +1,24 @@
 import os
 import threading
 import base64
+from typing import ClassVar
 from BaseClasses import MultiWorld, Tutorial, ItemClassification
 from worlds.AutoWorld import World, WebWorld
 from .items import item_table, item_groups, create_item, create_world_items, arch_item_offset, \
-    WORLD2_ACCESS_ITEM_ID, WORLD3_ACCESS_ITEM_ID, ITEM_CODE_GIL
+    WORLD2_ACCESS_ITEM_ID, WORLD3_ACCESS_ITEM_ID, ITEM_CODE_GIL, ITEM_CODE_FUNGIBLE
 from .locations import location_data, loc_id_start
 from .options import ffvcd_options
 from .regions import create_regions
 from .rules import set_rules
-from worlds.ffvcd.ffvcd_arch.utilities.data import conductor
-from worlds.ffvcd.ffvcd_arch.utilities.data import collectible
+from .ffvcd_arch.utilities.data import conductor
+from .ffvcd_arch.utilities.data import collectible
 from .client import FFVCDSNIClient
-from .rom import LocalRom, get_base_rom_path, patch_rom, FFVCDDeltaPatch
+from .rom import LocalRom, get_base_rom_path, patch_rom, FFVCDDeltaPatch, USHASH
 from collections import Counter
 import shutil
 import logging
 import pkgutil
+import settings
 from Fill import fill_restrictive
 
 logger = logging.getLogger("Final Fantasy V Career Day")
@@ -24,6 +26,15 @@ logger = logging.getLogger("Final Fantasy V Career Day")
 THIS_FILEPATH = os.path.dirname(__file__)
 
 # lots of credit to others in the repository, such as pokemonrb, dkc3 and tloz
+
+class FFVCDSettings(settings.Group):
+    class RomFile(settings.SNESRomPath):
+        """File name of the FFV J(1.0) rom with RPGe patch applied"""
+        description = "Final Fantasy V ROM File"
+        copy_to = "Final Fantasy V (J).sfc"
+        md5s = [USHASH]
+
+    rom_file: RomFile = RomFile(RomFile.copy_to)
 
 class FFVCDWebWorld(WebWorld):
     setup_en = Tutorial(
@@ -46,7 +57,7 @@ class FFVCDWorld(World):
     options_dataclass = ffvcd_options
     options: ffvcd_options
 
-    settings: None
+    settings: ClassVar[FFVCDSettings]
     
     
     topology_present = False
@@ -82,7 +93,6 @@ class FFVCDWorld(World):
             cls.rom_file = rom_file
             cls.source_rom_abs_path = os.path.abspath(Utils.user_path(rom_file))
 
-
     def generate_early(self):
         self.starting_items = Counter()
         self.world_lock = self.options.world_lock.value + 1
@@ -109,7 +119,13 @@ class FFVCDWorld(World):
             self.multiworld.push_precollected(new_item)
 
             
+    def create_item(self, name: str):
+        item_data = item_table[name]
+        return create_item(name, item_data.classification, item_data.id, self.player, item_data.groups)
 
+
+    def get_filler_item_name(self):
+        return self.random.choice([*item_groups[ITEM_CODE_FUNGIBLE], *item_groups[ITEM_CODE_GIL]])
 
 
     def create_items(self):

--- a/__init__.py
+++ b/__init__.py
@@ -117,16 +117,13 @@ class FFVCDWorld(World):
                         self.player, ['World Access'])
             self.starting_items[new_item] = 1
             self.multiworld.push_precollected(new_item)
-
             
     def create_item(self, name: str):
         item_data = item_table[name]
         return create_item(name, item_data.classification, item_data.id, self.player, item_data.groups)
 
-
     def get_filler_item_name(self):
         return self.random.choice([*item_groups[ITEM_CODE_FUNGIBLE], *item_groups[ITEM_CODE_GIL]])
-
 
     def create_items(self):
         
@@ -240,7 +237,6 @@ class FFVCDWorld(World):
             state = self.multiworld.get_all_state(False)
             fill_restrictive(self.multiworld, state, self.chosen_mib_locations, self.mib_items_to_place,
                                single_player_placement=True, lock=True, allow_excluded=True)
-        
 
     def create_regions(self):
         create_regions(self.multiworld, self.player)
@@ -358,6 +354,5 @@ class FFVCDWorld(World):
             new_name = base64.b64encode(bytes(self.rom_name)).decode()
             multidata["connect_names"][new_name] = multidata["connect_names"][self.multiworld.player_name[self.player]]
             
-        
     def write_spoiler(self, spoiler_handle) -> None:
         spoiler_handle.write(self.cond.spoiler)

--- a/rom.py
+++ b/rom.py
@@ -111,8 +111,8 @@ class LocalRom(object):
 
 
 
-def patch_rom(world, rom, player):
-    rom.name = bytearray(f'K7{__version__.replace(".", "")[0:3]}_{player}_{world.seed:11}\0', 'utf8')[:21]
+def patch_rom(multiworld, rom, player):
+    rom.name = bytearray(f'K7{__version__.replace(".", "")[0:3]}_{player}_{multiworld.seed:11}\0', 'utf8')[:21]
     rom.name.extend([0] * (21 - len(rom.name)))
     rom.write_bytes(0x7FC0, rom.name)
     

--- a/rules.py
+++ b/rules.py
@@ -1,11 +1,11 @@
 from worlds.generic.Rules import add_rule, set_rule, forbid_item
 
 def set_rules(ffvcdworld):
-    world = ffvcdworld.multiworld
+    multiworld = ffvcdworld.multiworld
     player = ffvcdworld.player
-    world.completion_condition[player] = lambda state: state.has("Victory", player)    
+    multiworld.completion_condition[player] = lambda state: state.has("Victory", player)
     
-    # set_rule(world.get_location("Kelb - CornaJar at Kelb (CornaJar)", ffvcdworld.player),
+    # set_rule(multiworld.get_location("Kelb - CornaJar at Kelb (CornaJar)", ffvcdworld.player),
     #       lambda state: state.has("Catch Ability", ffvcdworld.player) or
     #                     state.has("Trainer Crystal", ffvcdworld.player))
     


### PR DESCRIPTION
Added `create_item` on the FFVCD world object, as required by Archipelago world spec. This fixes plando and itemlink compatibility with the world (hopefully, since it was broken from generation side, the actual client half is completely untested). I also added `get_filler_item_name` to return specifically gil or fungible items. The default behavior is to return *any* possible item the world defines, including items we want to make unique.

Defined a settings class for FFVCD, hopefully resolving the influx of host.yaml issues.

Also changed some instances of world: MultiWorld I noticed, and a little PEP8 on _init_.

Tested by removing FF5 from my host yaml, and then attempting to generate with a yaml with plando items included.